### PR TITLE
Add image extensions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /data/
 /outputs/
 __pycache__
+# Ignore image files
+*.jpg
+*.png


### PR DESCRIPTION
To ensure we don't push images to the github repo, I have added them to the gitignore